### PR TITLE
Undo spacing

### DIFF
--- a/test/server.test.js
+++ b/test/server.test.js
@@ -122,16 +122,3 @@ describe("Post exercise", () => {
     expect(response.status).toBe(500);
   });
 });
-
-
-
-
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
As it turns out, branch protection doesn't cover repo admins. `git config branch.gomix.pushRemote no_push` was run locally to prevent accidental pushes to the repo from the default branch.